### PR TITLE
Us outlet end

### DIFF
--- a/TestHapuaMod.py
+++ b/TestHapuaMod.py
@@ -102,20 +102,19 @@ Runup = coast.runup(WavePeriod, Hs_offshore, PhysicalPars['BeachSlope'])
 #%% Morphology updating
 OldShoreY = ShoreY.copy()
 MorDt = TimePars['MorDtMin']
-(MorDt, Breach) =  = mor.updateMorphology(ShoreX, ShoreY, ShoreZ,
-                                          OutletEndX, OutletEndWidth, OutletEndElev, 
-                                          RiverElev, OnlineLagoon, 
-                                          OutletChanIx, LagoonWL, OutletDep,
-                                          ChanWidth, ChanDep, ChanDx, ChanFlag, 
-                                          Closed, LST, Bedload, CST_tot, OverwashProp,
-                                          MorDt, PhysicalPars, TimePars, NumericalPars)
+(MorDt, Breach) = mor.updateMorphology(ShoreX, ShoreY, ShoreZ,
+                                       OutletEndX, OutletEndWidth, OutletEndElev, 
+                                       RiverElev, OnlineLagoon, 
+                                       OutletChanIx, LagoonWL, OutletDep,
+                                       ChanWidth, ChanDep, ChanDx, ChanFlag, 
+                                       Closed, LST, Bedload, CST_tot, OverwashProp,
+                                       MorDt, PhysicalPars, TimePars, NumericalPars)
 plt.plot(ShoreX, (ShoreY[:,0]-OldShoreY[:,0]))
 
 #%% Create output netcdf file and write initial condition
 out.newOutFile('test.nc', ModelName, TimePars['StartTime'], 
                ShoreX, NumericalPars['Dx'],  RiverElev, 
-               Origin, ShoreNormDir, PhysicalPars['RiverWidth'],
-               False)
+               Origin, ShoreNormDir, PhysicalPars, False)
 out.writeCurrent('test.nc', TimePars['StartTime'], SeaLevel[-1], RivFlow[-1],
                  ShoreY, ShoreZ, LagoonWL, LagoonVel, np.zeros(ShoreX.size), 
                  OutletDep, OutletVel, np.zeros(ShoreX.size), 
@@ -126,4 +125,4 @@ out.writeCurrent('test.nc', TimePars['StartTime'], SeaLevel[-1], RivFlow[-1],
 
 #%% Test core timestepping
 ModelConfigFile = 'inputs\HurunuiModel.cnf'
-OutputTs = core.run(ModelConfigFile)
+OutputTs = core.main(ModelConfigFile)

--- a/hapuamod/loadmod.py
+++ b/hapuamod/loadmod.py
@@ -92,10 +92,10 @@ def loadModel(ModelConfigFile):
             upstream of lagoon (m)
         OutletEndX (np.ndarray(float64)): X-coordinate of upstream and 
             downstream ends of the outlet channel (m) 
-        OutletEndWidth (np.ndarray(float64)): Width of the upstream and 
-            downstream ends of the outlet channel (m)
-        OutletEndElev (np.ndarray(float64)): Bed level of the upstream and 
-            downstream ends of the outlet channel (m)
+        OutletEndWidth (float64): Width of the downstream end of the 
+            outlet channel (m)
+        OutletEndElev (float64): Bed level of the downstream end of the 
+            outlet channel (m)
         TimePars (dict): Time parameters including:
             StartTime (pd.datetime): Start date/time of simulation
             EndTime (pd.datetime): End date/time of simulation period
@@ -348,8 +348,8 @@ def loadModel(ModelConfigFile):
         
         # Setup outlet channel
         OutletEndX = np.asarray([0., 0.])
-        OutletEndWidth = np.full(2, IniCond['OutletWidth'])
-        OutletEndElev = np.asarray([IniCond['LagoonBed'], IniCond['OutletBed']])
+        OutletEndWidth = IniCond['OutletWidth']
+        OutletEndElev = IniCond['OutletBed']
         
         LagoonMask = ShoreX == 0
         ShoreY[LagoonMask, 1] = -PhysicalPars['SpitWidth']
@@ -538,18 +538,18 @@ def loadModel(ModelConfigFile):
                 OutletEndX[1] = np.min(ShoreX[OutletMask]) - Dx/2
                 
         # Set outlet end width
-        OutletEndWidth = np.full(2, IniCond['OutletWidth'])
+        OutletEndWidth = IniCond['OutletWidth']
         
         # Initialise lagoon bed elevation
         ShoreZ[: ,3] = np.full(ShoreX.size, IniCond['LagoonBed'])
         
         # Initialise outlet channel bed elevation
-        BedLevel = np.linspace(IniCond['LagoonBed'], IniCond['OutletBed'], np.sum(OutletMask)+2)
+        BedLevel = np.linspace(IniCond['LagoonBed'], IniCond['OutletBed'], np.sum(OutletMask)+1)
         if OutletToR:
-            ShoreZ[OutletMask, 1] = BedLevel[1:-1]
+            ShoreZ[OutletMask, 1] = BedLevel[:-1]
         else:
-            ShoreZ[OutletMask, 1] = np.flipud(BedLevel[1:-1])
-        OutletEndElev = BedLevel[[0,-1]]
+            ShoreZ[OutletMask, 1] = np.flipud(BedLevel[:-1])
+        OutletEndElev = BedLevel[-1]
         
         # Initialise barrier crest elevation
         ShoreZ[:, 0] = np.full(ShoreX.size, IniCond['BarrierElev'])

--- a/hapuamod/mor.py
+++ b/hapuamod/mor.py
@@ -81,7 +81,7 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
         AspectRatio = ChanWidth[1:-1]/ChanDep[1:-1]
         RivXS = ChanFlag[1:-1]==0
         LagXS = ChanFlag[1:-1]==1
-        OutXS = ChanFlag[1:-1]==2
+        OutXS = ChanFlag==2
         OutEndXS = ChanFlag[1:-1]==3
     TooWide = AspectRatio > PhysicalPars['WidthRatio']
     

--- a/hapuamod/mor.py
+++ b/hapuamod/mor.py
@@ -66,8 +66,8 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
     #%% Calculate rates of movement of morphology due to river forcing
     ShoreYChangeRate = np.zeros(ShoreY.shape)
     ShoreZChangeRate = np.zeros(ShoreZ.shape)
-    OutletEndWideningRate = np.zeros(2)
-    OutletEndXMoveRate = 0
+    OutletEndWideningRate = 0.0
+    OutletEndXMoveRate = 0.0
     
     if Closed:
         # Rate of change in volume at each cross-section (except the upstream Bdy)
@@ -81,8 +81,8 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
         AspectRatio = ChanWidth[1:-1]/ChanDep[1:-1]
         RivXS = ChanFlag[1:-1]==0
         LagXS = ChanFlag[1:-1]==1
-        OutXS = ChanFlag==3
-        OutEndXS = np.where(ChanFlag==2)[0]
+        OutXS = ChanFlag[1:-1]==2
+        OutEndXS = ChanFlag[1:-1]==3
     TooWide = AspectRatio > PhysicalPars['WidthRatio']
     
     EroVolRate = - np.minimum(DVolRate, 0.0)  # Total volumetric erosion rate (+ve = erosion)
@@ -100,7 +100,7 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
                                           / ((ShoreY[OnlineLagoon, 3] - ShoreY[OnlineLagoon, 4]) * Dx))
     if not Closed:
         ShoreZChangeRate[OutletChanIx, 1] += (BedDepRate[OutXS[1:-1]] - BedEroRate[OutXS[1:-1]]) / (ChanWidth[OutXS] * Dx)
-        OutletEndAggRate = (BedDepRate[OutEndXS-1] - BedEroRate[OutEndXS-1]) / (OutletEndWidth * Dx)
+        OutletEndAggRate = (BedDepRate[OutEndXS] - BedEroRate[OutEndXS]) / (OutletEndWidth * Dx)
     else:
         OutletEndAggRate = 0.0
     
@@ -114,14 +114,13 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
         ShoreYChangeRate[OutletChanIx,2] -= (BankEroRate[OutXS[1:-1]]/2) / ((ShoreZ[OutletChanIx,2] - ShoreZ[OutletChanIx,1]) * Dx)
         
         # Outlet end bank erosion
-        OutletEndWideningRate[0] += BankEroRate[OutEndXS[0]-1] / ((ShoreZ[OutletChanIx[0],0] - OutletEndElev[0]) * Dx)
-        OutletEndWideningRate[1] += BankEroRate[OutEndXS[1]-1] / ((PhysicalPars['BeachTopElev'] - OutletEndElev[1]) * PhysicalPars['SpitWidth'])
+        OutletEndWideningRate += BankEroRate[OutEndXS] / ((PhysicalPars['BeachTopElev'] - OutletEndElev) * PhysicalPars['SpitWidth'])
         if OutletEndX[0] < OutletEndX[1]:
             # Outlet angles from L to R
-            OutletEndXMoveRate += (OutletEndWideningRate[1] / 2) * PhysicalPars['OutletBankEroFac']
+            OutletEndXMoveRate += (OutletEndWideningRate / 2) * PhysicalPars['OutletBankEroFac']
         elif OutletEndX[0] > OutletEndX[1]:
             # Outlet angles from R to L
-            OutletEndXMoveRate -= (OutletEndWideningRate[1] / 2) * PhysicalPars['OutletBankEroFac']
+            OutletEndXMoveRate -= (OutletEndWideningRate / 2) * PhysicalPars['OutletBankEroFac']
         
         # Distribute sediment discharged from outlet onto shoreline 
         BedloadToShoreRate = ((Dx * Bedload[-1] / PhysicalPars['OutletSedSpreadDist']) * 
@@ -140,16 +139,16 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
             ShoreYChangeRate[OutletRbShoreIx,0] -= (LST[OutletRbShoreIx-1]
                                                     / (ShorefaceHeight[OutletRbShoreIx] * Dx))
             WidthReductionRate = (LST[OutletRbShoreIx-1] 
-                                  / ((PhysicalPars['BeachTopElev'] - OutletEndElev[1]) * PhysicalPars['SpitWidth']))
-            OutletEndWideningRate[1] -= WidthReductionRate
+                                  / ((PhysicalPars['BeachTopElev'] - OutletEndElev) * PhysicalPars['SpitWidth']))
+            OutletEndWideningRate -= WidthReductionRate
             OutletEndXMoveRate += WidthReductionRate/2
         else:
             # Transport from R to L
             ShoreY[OutletRbShoreIx-1,0] += (LST[OutletRbShoreIx-1] 
                                             / (ShorefaceHeight[OutletRbShoreIx-1] * Dx))
             WidthReductionRate = (-LST[OutletRbShoreIx-1]
-                                  / ((PhysicalPars['BeachTopElev'] - OutletEndElev[1]) * PhysicalPars['SpitWidth']))
-            OutletEndWideningRate[1] -= WidthReductionRate
+                                  / ((PhysicalPars['BeachTopElev'] - OutletEndElev) * PhysicalPars['SpitWidth']))
+            OutletEndWideningRate -= WidthReductionRate
             OutletEndXMoveRate -= WidthReductionRate/2
     
     #%% Rates of change of morphology due to cross-shore morphology (overtopping etc)
@@ -170,8 +169,8 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
     MaxMorChangeRate = max(np.max(np.abs(RivBedAggRate)),
                            np.max(np.abs(ShoreYChangeRate)),
                            np.max(np.abs(ShoreZChangeRate)),
-                           np.max(np.abs(OutletEndWideningRate)),
-                           np.max(np.abs(OutletEndAggRate)),
+                           abs(OutletEndWideningRate),
+                           abs(OutletEndAggRate),
                            abs(OutletEndXMoveRate))
     
     while MorDt.seconds > TimePars['MorDtMin'].seconds and MaxMorChangeRate * MorDt.seconds > NumericalPars['MaxMorChange']:
@@ -194,7 +193,7 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
         ShoreYChangeRate = np.minimum(np.maximum(ShoreYChangeRate, -MorChangeRateLimit), MorChangeRateLimit)
         ShoreZChangeRate = np.minimum(np.maximum(ShoreZChangeRate, -MorChangeRateLimit), MorChangeRateLimit)
         OutletEndWideningRate = np.minimum(np.maximum(OutletEndWideningRate, -MorChangeRateLimit), MorChangeRateLimit)
-        OutletEndAggRate = np.minimum(np.maximum(OutletEndAggRate, -MorChangeRateLimit), MorChangeRateLimit)
+        OutletEndAggRate = min(max(OutletEndAggRate, -MorChangeRateLimit), MorChangeRateLimit)
         OutletEndXMoveRate = min(max(OutletEndXMoveRate, -MorChangeRateLimit), MorChangeRateLimit)
     
     #%% Update morphology
@@ -291,9 +290,9 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
             # Dist from new outlet section to shoreline = PhysicalPars['SpitWidth']
             ShoreY[ExtendMask,1] = ShoreY[ExtendMask,0] - PhysicalPars['SpitWidth']
             # Width of new outlet section = end width
-            ShoreY[ExtendMask,2] = ShoreY[ExtendMask,1] - OutletEndWidth[1]
+            ShoreY[ExtendMask,2] = ShoreY[ExtendMask,1] - OutletEndWidth
             # Bed level of new outlet section  = end bed level
-            ShoreZ[ExtendMask,1] = OutletEndElev[1]
+            ShoreZ[ExtendMask,1] = OutletEndElev
             # Barrier height of inner barrier = Barrier height of old outer barrier
             ShoreZ[ExtendMask,2] = ShoreZ[ExtendMask,0]
             # Barrier height of outer barrier = PhysicalPars['BeachTopElev']
@@ -559,15 +558,15 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
             else:
                 # Outlet angles from R to L 
                 OutletEndX[1] = ShoreX[BreachIx] + Dx/2
-            OutletEndWidth[1] = Dx
-            OutletEndElev[1] = (ShoreZ[BreachIx,1] + PhysicalPars['MaxOutletElev'])/2
+            OutletEndWidth = Dx
+            OutletEndElev = (ShoreZ[BreachIx,1] + PhysicalPars['MaxOutletElev'])/2
             # TODO: close sediment balance by putting breach eroded sed onto shore
         else:
             # Lagoon breach (i.e. new outlet channel)
             logging.info('Breach/creation of new outlet channel at X = %f' % ShoreX[BreachIx])
             # Assume breach of width Dx with bed level linearly interpolated 
             # between lagoon level at upstream end and PhysicalPars['MaxOutletElev']
-            OutletEndWidth[:] = Dx
+            OutletEndWidth = Dx
             ShoreY[BreachIx,1] = min(ShoreY[BreachIx,0]-PhysicalPars['SpitWidth'],
                                      (ShoreY[BreachIx,0]+ShoreY[BreachIx,3])/2 + Dx/2)
             ShoreY[BreachIx,2] = ShoreY[BreachIx,1] - Dx
@@ -576,9 +575,8 @@ def updateMorphology(ShoreX, ShoreY, ShoreZ,
             
             ShoreZ[BreachIx, 2] = ShoreZ[BreachIx, 0]
             
-            OutletEndElev[0] = 0.25 * PhysicalPars['MaxOutletElev'] + 0.75 * ShoreZ[BreachIx,3]
-            ShoreZ[BreachIx,1] = 0.5 * PhysicalPars['MaxOutletElev'] + 0.5 * ShoreZ[BreachIx,3]
-            OutletEndElev[1] = 0.75 * PhysicalPars['MaxOutletElev'] + 0.25 * ShoreZ[BreachIx,3]
+            ShoreZ[BreachIx,1] = 0.34 * PhysicalPars['MaxOutletElev'] + 0.66 * ShoreZ[BreachIx,3]
+            OutletEndElev = 0.66 * PhysicalPars['MaxOutletElev'] + 0.34 * ShoreZ[BreachIx,3]
             
             # Check the newly created outlet channel fits into the barrier...
             if ShoreY[BreachIx,3] >= ShoreY[BreachIx,2]:

--- a/hapuamod/out.py
+++ b/hapuamod/out.py
@@ -268,30 +268,31 @@ def newOutFile(FileName, ModelName, StartTime,
     
     # Outlet end width
     OutletEndBVar = NcFile.createVariable('outlet_end_width', np.float32, 
-                                          (TimeDim.name, EndsDim.name))
+                                          TimeDim.name)
     OutletEndBVar.units = 'm'
     OutletEndBVar.long_name = 'Outlet end width'
     
     # Outlet end elevation
     OutletEndElevVar = NcFile.createVariable('outlet_end_z', np.float32, 
-                                             (TimeDim.name, EndsDim.name))
+                                             TimeDim.name)
     OutletEndElevVar.units = 'm'
     OutletEndElevVar.long_name = 'Outlet end bed elevation'
     
     # Outlet end water level
     OutletEndWlVar = NcFile.createVariable('outlet_end_wl', np.float32, 
-                                           (TimeDim.name, EndsDim.name))
+                                           TimeDim.name)
     OutletEndWlVar.units = 'm'
     OutletEndWlVar.long_name = 'Outlet end water level'
     
     # Outlet end velocity
     OutletEndVelVar = NcFile.createVariable('outlet_end_vel', np.float32, 
-                                            (TimeDim.name, EndsDim.name))
+                                            TimeDim.name)
     OutletEndVelVar.units = 'm/s'
     OutletEndVelVar.long_name = 'Outlet end velocity (+ve = outflowing i.e. towards sea)'
     
     # Outlet end bedload transport
-    OutletEndBedloadVar = NcFile.createVariable('outlet_end_bedload', np.float32, (TimeDim.name, EndsDim.name))
+    OutletEndBedloadVar = NcFile.createVariable('outlet_end_bedload', np.float32, 
+                                                TimeDim.name)
     OutletEndBedloadVar.units = 'm3(bulk including voids)/s'
     OutletEndBedloadVar.long_name = 'bedlaod transport at outlet channel ends (+ve = outflowing i.e. towards sea)'
     
@@ -369,10 +370,10 @@ def writeCurrent(FileName, CurrentTime, SeaLevel, RivFlow,
     
     # Append new data to outlet end variables
     NcFile.variables['outlet_end_x'][TimeIx,:] = OutletEndX
-    NcFile.variables['outlet_end_width'][TimeIx,:] = OutletEndWidth
-    NcFile.variables['outlet_end_z'][TimeIx,:] = OutletEndElev
-    NcFile.variables['outlet_end_wl'][TimeIx,:] = OutletEndElev + OutletEndDep[0:2]
-    NcFile.variables['outlet_end_vel'][TimeIx,:] = OutletEndVel[0:2]
+    NcFile.variables['outlet_end_width'][TimeIx] = OutletEndWidth
+    NcFile.variables['outlet_end_z'][TimeIx] = OutletEndElev
+    NcFile.variables['outlet_end_wl'][TimeIx] = OutletEndElev + OutletEndDep[0]
+    NcFile.variables['outlet_end_vel'][TimeIx] = OutletEndVel[0]
     NcFile.variables['outlet_closed'][TimeIx] = Closed
     
     NcFile.close()
@@ -427,10 +428,10 @@ def readTimestep(NcFile, TimeIx):
     OutletVel = NcFile.variables['outlet_vel'][TimeIx,:]
     
     OutletEndX = NcFile.variables['outlet_end_x'][TimeIx,:].squeeze()
-    OutletEndWidth = NcFile.variables['outlet_end_width'][TimeIx,:].squeeze()
-    OutletEndElev = NcFile.variables['outlet_end_z'][TimeIx,:].squeeze()
-    OutletEndVel = NcFile.variables['outlet_end_vel'][TimeIx,:].squeeze()
-    OutletEndWL = NcFile.variables['outlet_end_wl'][TimeIx,:].squeeze()
+    OutletEndWidth = NcFile.variables['outlet_end_width'][TimeIx]
+    OutletEndElev = NcFile.variables['outlet_end_z'][TimeIx]
+    OutletEndVel = NcFile.variables['outlet_end_vel'][TimeIx]
+    OutletEndWL = NcFile.variables['outlet_end_wl'][TimeIx]
     Closed = bool(NcFile.variables['outlet_closed'][TimeIx])
     
     WavePower=None

--- a/hapuamod/out.py
+++ b/hapuamod/out.py
@@ -16,9 +16,10 @@ def newOutFile(FileName, ModelName, StartTime,
                Overwrite=False):
     """ Create new netCDF output file for hapuamod results
     
-        newOutFile(FileName, ModelName, ShoreX, Dx, RiverElev, 
-                   Origin, ShoreNormDir, RiverWidth,
-                   StartTime, Overwrite=False)
+        newOutFile(FileName, ModelName, StartTime, 
+                   ShoreX, Dx, RiverElev, 
+                   Origin, ShoreNormDir, PhysicalPars,
+                   Overwrite=False)
     
         Parameters:
             FileName (string):

--- a/hapuamod/riv.py
+++ b/hapuamod/riv.py
@@ -304,7 +304,7 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
                 'online' - similar to OnlineLagoon
             ChanFlag: Flags showing the origin of the different cross-sections
                 making up the outlet channel. 0 = river, 1 = lagoon,
-                2 = outlet channel ends, 3 = outlet channel.
+                2 = outlet channel, 3 = outlet channel end, 4 = dummy XS in sea.
             Closed (boolean): Is the channel closed or open at its downstream 
                 end?
     """
@@ -331,11 +331,11 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
         OutletWidth[np.isnan(OutletWidth)] = 0.
     
         # Check if closure has occured in outlet channel (only if not already closed from previous timestep).
-        if np.any(OutletWidth<=PhysicalPars['MinOutletWidth']) | np.any(OutletEndWidth<=PhysicalPars['MinOutletWidth']):
+        if np.any(OutletWidth<=PhysicalPars['MinOutletWidth']) | OutletEndWidth<=PhysicalPars['MinOutletWidth']:
             Closed = True
             for ClosedIx in OutletChanIx[OutletWidth<=PhysicalPars['MinOutletWidth']]:
                 logging.info('Outlet channel closed by wave washover at X = %f' % ShoreX[ClosedIx])
-            if OutletEndWidth[1] <= PhysicalPars['MinOutletWidth']:
+            if OutletEndWidth <= PhysicalPars['MinOutletWidth']:
                 logging.info('Downstream end of outlet channel closed by longshore transport (EndX = %f)' % OutletEndX[1])
             OutletChanIx = np.empty(0)
         elif np.min(OutletWidth) < PhysicalPars['MinOutletWidth'] * 3:
@@ -408,7 +408,7 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
         ChanWidth = np.concatenate([np.full(RiverElev.size, PhysicalPars['RiverWidth']), 
                                     LagoonWidth[OnlineLagoon]])
     else: # open
-        ChanDx = np.full(RiverElev.size + OnlineLagoon.size + OutletChanIx.size + 2, Dx)
+        ChanDx = np.full(RiverElev.size + OnlineLagoon.size + OutletChanIx.size + 1, Dx)
         if OutletEndX[0] < OutletEndX[1]:
             # Outlet angles from L to R
             ChanDx[-2] += OutletEndX[1] % Dx
@@ -417,13 +417,13 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
             ChanDx[-2] += Dx - (OutletEndX[1] % Dx)
         ChanFlag = np.concatenate([np.full(RiverElev.size, 0), 
                                    np.full(OnlineLagoon.size, 1), 
-                                   [2], np.full(OutletChanIx.size, 3), [2,4]])
+                                   np.full(OutletChanIx.size, 2), [3,4]])
         ChanElev = np.concatenate([RiverElev, ShoreZ[OnlineLagoon,3], 
-                                   [OutletEndElev[0]], ShoreZ[OutletChanIx,1], 
-                                   [OutletEndElev[1], min(PhysicalPars['MaxOutletElev'], OutletEndElev[1])]])
+                                   ShoreZ[OutletChanIx,1], 
+                                   [OutletEndElev, min(PhysicalPars['MaxOutletElev'], OutletEndElev)]])
         ChanWidth = np.concatenate([np.full(RiverElev.size, PhysicalPars['RiverWidth']), 
-                                    LagoonWidth[OnlineLagoon], [OutletEndWidth[0]],
-                                    OutletWidth, np.full(2, OutletEndWidth[1])])
+                                    LagoonWidth[OnlineLagoon], OutletWidth, 
+                                    np.full(2, OutletEndWidth)])
     LagArea = np.zeros(ChanElev.size)
     LagArea[RiverElev.size] = StartArea
     LagArea[RiverElev.size + OnlineLagoon.size - 1] = EndArea
@@ -438,14 +438,12 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
     else:
         ChanDep = np.concatenate([RivDep,
                                   LagoonWL[OnlineLagoon]-ShoreZ[OnlineLagoon,3],
-                                  [OutletEndDep[0]], 
                                   OutletDep[OutletChanIx], 
-                                  OutletEndDep[1:]])
+                                  OutletEndDep])
         ChanVel = np.concatenate([RivVel,
-                                  LagoonVel[OnlineLagoon],
-                                  [OutletEndVel[0]], 
+                                  LagoonVel[OnlineLagoon], 
                                   OutletVel[OutletChanIx], 
-                                  OutletEndVel[1:]])
+                                  OutletEndVel])
     # If depth is missing then interpolate it
     DepNan = np.isnan(ChanDep)
     if np.any(DepNan):
@@ -511,9 +509,9 @@ def storeHydraulics(ChanDep, ChanVel, OnlineLagoon, OutletChanIx, ChanFlag,
         OutletEndDep = np.full(3, np.nan)
         OutletEndVel = np.full(3, np.nan)
     else:        
-        OutletDep[OutletChanIx] = ChanDep[ChanFlag==3]
-        OutletVel[OutletChanIx] = ChanVel[ChanFlag==3]
-        EndNodes = np.logical_or(ChanFlag==2, ChanFlag==4)
+        OutletDep[OutletChanIx] = ChanDep[ChanFlag==2]
+        OutletVel[OutletChanIx] = ChanVel[ChanFlag==2]
+        EndNodes = np.logical_or(ChanFlag==3, ChanFlag==4)
         OutletEndDep = ChanDep[EndNodes]
         OutletEndVel = ChanVel[EndNodes]
     
@@ -589,11 +587,11 @@ def storeBedload(Bedload, NTransects, OnlineLagoon, OutletChanIx,
     OutletBedload = np.zeros(NTransects)
     LagoonBedload = np.zeros(NTransects)
     if Closed:
-        OutletEndBedload = np.zeros(2)
+        OutletEndBedload = 0.0
         LagoonBedload[OnlineLagoon[:-1]] = Bedload[ChanFlag[:-1]==1]
     else:        
-        OutletBedload[OutletChanIx] = Bedload[ChanFlag[:-1]==3]
-        OutletEndBedload = Bedload[ChanFlag[:-1]==2]
+        OutletBedload[OutletChanIx] = Bedload[ChanFlag[:-1]==2]
+        OutletEndBedload = Bedload[ChanFlag[:-1]==3]
         LagoonBedload[OnlineLagoon] = Bedload[ChanFlag[:-1]==1]
     
     return (LagoonBedload, OutletBedload, OutletEndBedload)

--- a/hapuamod/riv.py
+++ b/hapuamod/riv.py
@@ -312,9 +312,9 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
     X0Ix = np.where(ShoreX==0)[0][0]
     
     # Handle the postprocessing situation when we don't have (or need) a dummy XS in the sea
-    if OutletEndDep.size == 2:
+    if OutletEndDep.size == 1:
         OutletEndDep = np.append(OutletEndDep, np.nan)
-    if OutletEndVel.size == 2:
+    if OutletEndVel.size == 1:
         OutletEndVel = np.append(OutletEndVel, np.nan)
     
     if not Closed:
@@ -331,7 +331,7 @@ def assembleChannel(ShoreX, ShoreY, ShoreZ,
         OutletWidth[np.isnan(OutletWidth)] = 0.
     
         # Check if closure has occured in outlet channel (only if not already closed from previous timestep).
-        if np.any(OutletWidth<=PhysicalPars['MinOutletWidth']) | OutletEndWidth<=PhysicalPars['MinOutletWidth']:
+        if np.any(OutletWidth<=PhysicalPars['MinOutletWidth']) | (OutletEndWidth<=PhysicalPars['MinOutletWidth']):
             Closed = True
             for ClosedIx in OutletChanIx[OutletWidth<=PhysicalPars['MinOutletWidth']]:
                 logging.info('Outlet channel closed by wave washover at X = %f' % ShoreX[ClosedIx])

--- a/hapuamod/visualise.py
+++ b/hapuamod/visualise.py
@@ -284,11 +284,12 @@ def updateModelView(ModelFig, ShoreX, ShoreY, OutletEndX, OutletEndWidth,
         LagoonLeftEndX = np.min(ShoreX[LagoonPresent]) - Dx
         LagoonRightEndX = np.max(ShoreX[LagoonPresent]) + Dx
         
-        OutletUsLbPlotX = max(OutletEndX[0] - OutletEndWidth[0]/2, LagoonLeftEndX)
-        OutletUsRbPlotX = min(OutletEndX[0] + OutletEndWidth[0]/2, LagoonRightEndX)
+        UsOutletEndWidth = ShoreY[OutletChanIx[0],1] - ShoreY[OutletChanIx[0],2]
+        OutletUsLbPlotX = max(OutletEndX[0] - UsOutletEndWidth/2, LagoonLeftEndX)
+        OutletUsRbPlotX = min(OutletEndX[0] + UsOutletEndWidth/2, LagoonRightEndX)
         
-        OutletDsLbX = OutletEndX[1] - OutletEndWidth[1]/2
-        OutletDsRbX = OutletEndX[1] + OutletEndWidth[1]/2
+        OutletDsLbX = OutletEndX[1] - OutletEndWidth/2
+        OutletDsRbX = OutletEndX[1] + OutletEndWidth/2
         
         # Outlet plotting position
         if OutletUsLbPlotX < OutletDsLbX:
@@ -318,7 +319,7 @@ def updateModelView(ModelFig, ShoreX, ShoreY, OutletEndX, OutletEndWidth,
                                    np.interp(OutletUsLbPlotX, ShoreX[np.flip(OutletChanIx)], 
                                              ShoreY[np.flip(OutletChanIx), 2]),
                                    ShoreY[OutletChanIx[L_Ok],2],
-                                   max(np.interp(OutletLbX[-2], ShoreX, ShoreY[:,0]) - SpitWidth - OutletEndWidth[1],
+                                   max(np.interp(OutletLbX[-2], ShoreX, ShoreY[:,0]) - SpitWidth - OutletEndWidth,
                                        np.interp(OutletLbX[-2], ShoreX, ShoreY[:,3])),
                                    np.NaN, # This point is extra - gets interpolated below
                                    np.interp(OutletDsLbX, ShoreX, ShoreY[:,0])])
@@ -338,7 +339,7 @@ def updateModelView(ModelFig, ShoreX, ShoreY, OutletEndX, OutletEndWidth,
                                    np.interp(OutletUsRbPlotX, ShoreX[OutletChanIx],
                                              ShoreY[OutletChanIx, 2]),
                                    ShoreY[OutletChanIx[R_Ok],2],
-                                   max(np.interp(OutletRbX[-2], ShoreX, ShoreY[:,0]) - SpitWidth - OutletEndWidth[1],
+                                   max(np.interp(OutletRbX[-2], ShoreX, ShoreY[:,0]) - SpitWidth - OutletEndWidth,
                                        np.interp(OutletRbX[-2], ShoreX, ShoreY[:,3])),
                                    np.NaN, # Extra point
                                    np.interp(OutletDsRbX, ShoreX, ShoreY[:,0])])


### PR DESCRIPTION
Removing cross-section from upstream end of outlet channel. Previously the river model was constructed from: 1: River XS, 2: Lagoon XS, 3. Upstream outlet end XS, 4, Outlet channel XS, 5 Downstream outlet end XS, 6: Dummy XS in sea. However there were issues caused by the fact there was no way for the upstream outlet XS to narrow. It looked weird in the plotting if it was overwide and also has the potential to cause hydraulic instabilities (#74).

This changes remove all upstream outlet cross-section. This means there is no need to track its width or bed level, or include it in the river model. Note that the X coordinate of the upstream end of the outlet channel is still tracked. Plotting/animation routines have also been changed and the upstream most outlet channel XS width is now used to set the width on the upstream end of the outlet for plotting purposes.

Closes #74